### PR TITLE
Add test for multiple namespaces

### DIFF
--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -63,8 +63,8 @@ def trustyai_service(
     client,
     model_namespace,
     modelmesh_serviceaccount,
-    # cluster_monitoring_config,
-    # user_workload_monitoring_config,
+    cluster_monitoring_config,
+    user_workload_monitoring_config,
 ):
     with TrustyAIService(
         client=client,

--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -8,6 +8,7 @@ from ocp_resources.trustyai_service import TrustyAIService
 
 from trustyai_tests.tests.constants import (
     TRUSTYAI_SERVICE,
+    MINIO_DATA_CONNECTION_NAME,
 )
 from trustyai_tests.tests.minio import MinioSecret, MinioPod, MinioService
 
@@ -103,7 +104,7 @@ def minio_pod(client, model_namespace):
 def minio_secret(client, model_namespace):
     with MinioSecret(
         client=client,
-        name="aws-connection-minio-data-connection",
+        name=MINIO_DATA_CONNECTION_NAME,
         namespace=model_namespace.name,
         # Dummy AWS values
         aws_access_key_id="VEhFQUNDRVNTS0VZ",

--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -63,8 +63,8 @@ def trustyai_service(
     client,
     model_namespace,
     modelmesh_serviceaccount,
-    cluster_monitoring_config,
-    user_workload_monitoring_config,
+    # cluster_monitoring_config,
+    # user_workload_monitoring_config,
 ):
     with TrustyAIService(
         client=client,

--- a/trustyai_tests/tests/constants.py
+++ b/trustyai_tests/tests/constants.py
@@ -9,3 +9,5 @@ TRUSTYAI_API_GROUP = "trustyai.opendatahub.io"
 OPENDATAHUB_IO = "opendatahub.io"
 
 MODEL_DATA_PATH = "./trustyai_tests/model_data"
+
+MINIO_DATA_CONNECTION_NAME = "aws-connection-minio-data-connection"

--- a/trustyai_tests/tests/drift/test_drift.py
+++ b/trustyai_tests/tests/drift/test_drift.py
@@ -7,7 +7,7 @@ from trustyai_tests.tests.utils import (
     verify_metric_request,
     verify_metric_scheduling,
     upload_data_to_trustyai_service,
-    wait_for_model_pods_registered,
+    wait_for_modelmesh_pods_registered,
 )
 from trustyai_tests.tests.constants import (
     MODEL_DATA_PATH,
@@ -28,7 +28,7 @@ class TestDriftMetrics:
     """
 
     def test_gaussian_credit_model_metadata(self, model_namespace, trustyai_service, gaussian_credit_model):
-        wait_for_model_pods_registered(namespace=model_namespace)
+        wait_for_modelmesh_pods_registered(namespace=model_namespace)
 
         path = f"{MODEL_DATA_PATH}/{gaussian_credit_model.name}"
 

--- a/trustyai_tests/tests/fairness/conftest.py
+++ b/trustyai_tests/tests/fairness/conftest.py
@@ -2,20 +2,25 @@ import pytest
 
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.serving_runtime import ServingRuntime
+from ocp_resources.trustyai_service import TrustyAIService
 
 from trustyai_tests.tests.constants import (
     OPENVINO_MODEL_FORMAT,
     KSERVE_API_GROUP,
+    TRUSTYAI_SERVICE,
+    MINIO_DATA_CONNECTION_NAME,
 )
+from trustyai_tests.tests.fairness.utils import deploy_namespace_with_minio
+from trustyai_tests.tests.utils import wait_for_model_pods_registered
 
 ONNX = "onnx"
 OVMS = "ovms"
 OVMS_RUNTIME_NAME = f"{OVMS}-1.x"
 OVMS_QUAY_IMAGE = "quay.io/opendatahub/openvino_model_server:stable"
+ONNX_LOAN_MODEL_ALPHA_PATH = "onnx/loan_model_alpha_august.onnx"
 
 
-@pytest.fixture(scope="class")
-def ovms_runtime(client, minio_data_connection, model_namespace):
+def create_ovms_runtime(namespace):
     supported_model_formats = [
         {"name": OPENVINO_MODEL_FORMAT, "version": "opset1", "autoSelect": True},
         {"name": ONNX, "version": "1"},
@@ -39,10 +44,9 @@ def ovms_runtime(client, minio_data_connection, model_namespace):
         }
     ]
 
-    with ServingRuntime(
-        client=client,
+    return ServingRuntime(
         name=OVMS_RUNTIME_NAME,
-        namespace=model_namespace.name,
+        namespace=namespace.name,
         containers=containers,
         supported_model_formats=supported_model_formats,
         multi_model=True,
@@ -59,7 +63,12 @@ def ovms_runtime(client, minio_data_connection, model_namespace):
         label={
             "name": f"modelmesh-serving-{OVMS_RUNTIME_NAME}-SR",
         },
-    ) as ovms:
+    )
+
+
+@pytest.fixture(scope="class")
+def ovms_runtime(minio_data_connection, model_namespace):
+    with create_ovms_runtime(model_namespace) as ovms:
         yield ovms
 
 
@@ -97,3 +106,72 @@ def onnx_loan_model_beta(client, model_namespace, minio_data_connection, ovms_ru
         annotations={f"{KSERVE_API_GROUP}/deploymentMode": "ModelMesh"},
     ) as inference_service:
         yield inference_service
+
+
+@pytest.fixture(scope="class")
+def model_namespaces_with_minio():
+    namespaces = []
+
+    for i in range(3):
+        namespace = deploy_namespace_with_minio(name=f"test-namespace-{i}")
+        namespaces.append(namespace)
+
+    yield namespaces
+    for namespace in namespaces:
+        namespace.delete(wait=True)
+
+
+@pytest.fixture(scope="class")
+def trustyai_services_in_namespaces(model_namespaces_with_minio):
+    trustyai_services = []
+
+    for namespace in model_namespaces_with_minio:
+        trustyai_service = TrustyAIService(
+            name=TRUSTYAI_SERVICE,
+            namespace=namespace.name,
+            storage={"format": "PVC", "folder": "/inputs", "size": "1Gi"},
+            data={"filename": "data.csv", "format": "CSV"},
+            metrics={"schedule": "5s"},
+        )
+        trustyai_service.deploy()
+        trustyai_services.append(trustyai_service)
+    yield trustyai_services
+    for trustyai_service in trustyai_services:
+        trustyai_service.delete(wait=True)
+
+
+@pytest.fixture(scope="class")
+def ovms_runtimes_in_namespaces(model_namespaces_with_minio):
+    ovms_runtimes = []
+
+    for namespace in model_namespaces_with_minio:
+        ovms_runtime = create_ovms_runtime(namespace=namespace)
+        ovms_runtime.deploy()
+        ovms_runtimes.append(ovms_runtime)
+    yield ovms_runtimes
+    for ovms_runtime in ovms_runtimes:
+        ovms_runtime.delete(wait=True)
+
+
+@pytest.fixture(scope="class")
+def onnx_loan_models_in_namespaces(model_namespaces_with_minio, ovms_runtimes_in_namespaces):
+    inference_services = []
+    for namespace, ovms_runtime in zip(model_namespaces_with_minio, ovms_runtimes_in_namespaces):
+        inference_service = InferenceService(
+            name="demo-loan-nn-onnx-alpha",
+            namespace=namespace.name,
+            predictor={
+                "model": {
+                    "modelFormat": {"name": ONNX},
+                    "runtime": ovms_runtime.name,
+                    "storage": {"key": MINIO_DATA_CONNECTION_NAME, "path": ONNX_LOAN_MODEL_ALPHA_PATH},
+                }
+            },
+            annotations={f"{KSERVE_API_GROUP}/deploymentMode": "ModelMesh"},
+        )
+        inference_service.deploy()
+        wait_for_model_pods_registered(namespace=namespace)
+        inference_services.append(inference_service)
+    yield inference_services
+    for inference_service in inference_services:
+        inference_service.delete(wait=True)

--- a/trustyai_tests/tests/fairness/conftest.py
+++ b/trustyai_tests/tests/fairness/conftest.py
@@ -11,7 +11,7 @@ from trustyai_tests.tests.constants import (
     MINIO_DATA_CONNECTION_NAME,
 )
 from trustyai_tests.tests.fairness.utils import deploy_namespace_with_minio
-from trustyai_tests.tests.utils import wait_for_model_pods_registered
+from trustyai_tests.tests.utils import wait_for_modelmesh_pods_registered
 
 ONNX = "onnx"
 OVMS = "ovms"
@@ -170,7 +170,7 @@ def onnx_loan_models_in_namespaces(model_namespaces_with_minio, ovms_runtimes_in
             annotations={f"{KSERVE_API_GROUP}/deploymentMode": "ModelMesh"},
         )
         inference_service.deploy()
-        wait_for_model_pods_registered(namespace=namespace)
+        wait_for_modelmesh_pods_registered(namespace=namespace)
         inference_services.append(inference_service)
     yield inference_services
     for inference_service in inference_services:

--- a/trustyai_tests/tests/fairness/test_fairness.py
+++ b/trustyai_tests/tests/fairness/test_fairness.py
@@ -7,7 +7,7 @@ from trustyai_tests.tests.utils import (
     verify_metric_scheduling,
     apply_trustyai_name_mappings,
     verify_trustyai_metric_prometheus,
-    wait_for_model_pods_registered,
+    wait_for_modelmesh_pods_registered,
 )
 
 
@@ -57,7 +57,7 @@ class TestFairnessMetrics:
     """
 
     def test_loan_model_metadata(self, model_namespace, trustyai_service, onnx_loan_model_alpha, onnx_loan_model_beta):
-        wait_for_model_pods_registered(namespace=model_namespace)
+        wait_for_modelmesh_pods_registered(namespace=model_namespace)
 
         for model in [onnx_loan_model_alpha, onnx_loan_model_beta]:
             send_data_to_inference_service(

--- a/trustyai_tests/tests/fairness/test_fairness.py
+++ b/trustyai_tests/tests/fairness/test_fairness.py
@@ -13,6 +13,33 @@ from trustyai_tests.tests.utils import (
 
 IS_MALE_IDENTIFYING = "Is Male-Identifying?"
 WILL_DEFAULT = "Will Default?"
+INPUT_MAPPINGS = {
+    "customer_data_input-0": "Number of Children",
+    "customer_data_input-1": "Total Income",
+    "customer_data_input-2": "Number of Total Family Members",
+    "customer_data_input-3": IS_MALE_IDENTIFYING,
+    "customer_data_input-4": "Owns Car?",
+    "customer_data_input-5": "Owns Realty?",
+    "customer_data_input-6": "Is Partnered?",
+    "customer_data_input-7": "Is Employed?",
+    "customer_data_input-8": "Live with Parents?",
+    "customer_data_input-9": "Age",
+    "customer_data_input-10": "Length of Employment?",
+}
+OUTPUT_MAPPINGS = {"predict": WILL_DEFAULT}
+INPUT_DATA_PATH = f"{MODEL_DATA_PATH}/loan-nn-onnx"
+
+
+def get_json_data(inference_service):
+    return {
+        "modelId": inference_service.name,
+        "protectedAttribute": IS_MALE_IDENTIFYING,
+        "privilegedAttribute": 1.0,
+        "unprivilegedAttribute": 0.0,
+        "outcomeName": WILL_DEFAULT,
+        "favorableOutcome": 0,
+        "batchSize": 5000,
+    }
 
 
 class TestFairnessMetrics:
@@ -20,8 +47,8 @@ class TestFairnessMetrics:
     Verifies the different fairness metrics available in TrustyAI.
     Fairness metrics: Statistical Parity Difference (SPD) and Disparate Impact Ratio (DIR).
 
-    1. Send data to the model (onnx_loan_model_alpha).
-    2. Send data to the model.
+    1. Send data to the inference_service (onnx_loan_model_alpha).
+    2. Send data to the inference_service.
     3. Apply name mappings.
     4. For each metric:
         4.1. Send a basic request and verify the response.
@@ -32,38 +59,24 @@ class TestFairnessMetrics:
     def test_loan_model_metadata(self, model_namespace, trustyai_service, onnx_loan_model_alpha, onnx_loan_model_beta):
         wait_for_model_pods_registered(namespace=model_namespace)
 
-        input_data_path = f"{MODEL_DATA_PATH}/loan-nn-onnx"
-
         for model in [onnx_loan_model_alpha, onnx_loan_model_beta]:
             send_data_to_inference_service(
                 inference_service=model,
                 namespace=model_namespace,
-                data_path=input_data_path,
+                data_path=INPUT_DATA_PATH,
             )
 
             apply_trustyai_name_mappings(
                 namespace=model_namespace,
                 inference_service=model,
-                input_mappings={
-                    "customer_data_input-0": "Number of Children",
-                    "customer_data_input-1": "Total Income",
-                    "customer_data_input-2": "Number of Total Family Members",
-                    "customer_data_input-3": IS_MALE_IDENTIFYING,
-                    "customer_data_input-4": "Owns Car?",
-                    "customer_data_input-5": "Owns Realty?",
-                    "customer_data_input-6": "Is Partnered?",
-                    "customer_data_input-7": "Is Employed?",
-                    "customer_data_input-8": "Live with Parents?",
-                    "customer_data_input-9": "Age",
-                    "customer_data_input-10": "Length of Employment?",
-                },
-                output_mappings={"predict": WILL_DEFAULT},
+                input_mappings=INPUT_MAPPINGS,
+                output_mappings=OUTPUT_MAPPINGS,
             )
 
             verify_trustyai_model_metadata(
                 namespace=model_namespace,
                 model=model,
-                data_path=input_data_path,
+                data_path=INPUT_DATA_PATH,
                 expected_percentage_observations=0.3,
             )
 
@@ -74,15 +87,7 @@ class TestFairnessMetrics:
                 model=model,
                 endpoint=get_metric_endpoint(metric=Metric.SPD),
                 expected_metric_name=Metric.SPD.value.upper(),
-                json_data={
-                    "modelId": model.name,
-                    "protectedAttribute": IS_MALE_IDENTIFYING,
-                    "privilegedAttribute": 1.0,
-                    "unprivilegedAttribute": 0.0,
-                    "outcomeName": WILL_DEFAULT,
-                    "favorableOutcome": 0,
-                    "batchSize": 5000,
-                },
+                json_data=get_json_data(model),
             )
 
     def test_schedule_spd(self, model_namespace, trustyai_service, onnx_loan_model_alpha, onnx_loan_model_beta):
@@ -91,15 +96,7 @@ class TestFairnessMetrics:
                 namespace=model_namespace,
                 model=model,
                 endpoint=get_metric_endpoint(metric=Metric.SPD, schedule=True),
-                json_data={
-                    "modelId": model.name,
-                    "protectedAttribute": IS_MALE_IDENTIFYING,
-                    "privilegedAttribute": 1.0,
-                    "unprivilegedAttribute": 0.0,
-                    "outcomeName": WILL_DEFAULT,
-                    "favorableOutcome": 0,
-                    "batchSize": 5000,
-                },
+                json_data=get_json_data(model),
             )
 
     def test_spd_prometheus_query(self, model_namespace, onnx_loan_model_alpha, onnx_loan_model_beta):
@@ -118,15 +115,7 @@ class TestFairnessMetrics:
                 model=model,
                 endpoint=get_metric_endpoint(metric=Metric.DIR),
                 expected_metric_name=Metric.DIR.value.upper(),
-                json_data={
-                    "modelId": model.name,
-                    "protectedAttribute": IS_MALE_IDENTIFYING,
-                    "privilegedAttribute": 1.0,
-                    "unprivilegedAttribute": 0.0,
-                    "outcomeName": WILL_DEFAULT,
-                    "favorableOutcome": 0,
-                    "batchSize": 5000,
-                },
+                json_data=get_json_data(model),
             )
 
     def test_schedule_dir(self, model_namespace, trustyai_service, onnx_loan_model_alpha, onnx_loan_model_beta):
@@ -135,22 +124,66 @@ class TestFairnessMetrics:
                 namespace=model_namespace,
                 model=model,
                 endpoint=get_metric_endpoint(metric=Metric.DIR, schedule=True),
-                json_data={
-                    "modelId": model.name,
-                    "protectedAttribute": IS_MALE_IDENTIFYING,
-                    "privilegedAttribute": 1.0,
-                    "unprivilegedAttribute": 0.0,
-                    "outcomeName": WILL_DEFAULT,
-                    "favorableOutcome": 0,
-                    "batchSize": 5000,
-                },
+                json_data=get_json_data(model),
             )
 
     def test_dir_prometheus_query(self, model_namespace, onnx_loan_model_alpha, onnx_loan_model_beta):
-        for model in [onnx_loan_model_alpha, onnx_loan_model_beta]:
+        for inference_service in [onnx_loan_model_alpha, onnx_loan_model_beta]:
             verify_trustyai_metric_prometheus(
                 namespace=model_namespace,
-                model=model,
+                model=inference_service,
                 prometheus_query=f"trustyai_{Metric.DIR.value}" f'{{namespace="{model_namespace.name}"}}',
                 metric_name=Metric.DIR.value,
             )
+
+
+class TestMultipleNamespaces:
+    """
+    Tests that TrustyAI Operator can handle multiple namespaces.
+    Creates three namespaces, deploys TrustyAIService on each, as well as an InferenceService,
+    sends data to the InferenceService and sends several fairness metric requests.
+    """
+
+    def test_multiple_namespaces(
+        self,
+        model_namespaces_with_minio,
+        trustyai_services_in_namespaces,
+        ovms_runtimes_in_namespaces,
+        onnx_loan_models_in_namespaces,
+    ):
+        for namespace, inference_service in zip(model_namespaces_with_minio, onnx_loan_models_in_namespaces):
+            send_data_to_inference_service(
+                inference_service=inference_service,
+                namespace=namespace,
+                data_path=INPUT_DATA_PATH,
+                num_batches=3,
+            )
+
+            apply_trustyai_name_mappings(
+                namespace=namespace,
+                inference_service=inference_service,
+                input_mappings=INPUT_MAPPINGS,
+                output_mappings=OUTPUT_MAPPINGS,
+            )
+
+            verify_trustyai_model_metadata(
+                namespace=namespace,
+                model=inference_service,
+                data_path=INPUT_DATA_PATH,
+                expected_percentage_observations=0.1,
+            )
+
+            for metric in (Metric.SPD, Metric.DIR):
+                verify_metric_scheduling(
+                    namespace=namespace,
+                    model=inference_service,
+                    endpoint=get_metric_endpoint(metric=metric, schedule=True),
+                    json_data=get_json_data(inference_service),
+                )
+
+                verify_trustyai_metric_prometheus(
+                    namespace=namespace,
+                    model=inference_service,
+                    prometheus_query=f"trustyai_{metric.value}" f'{{namespace="{namespace.name}"}}',
+                    metric_name=metric.value,
+                )

--- a/trustyai_tests/tests/fairness/utils.py
+++ b/trustyai_tests/tests/fairness/utils.py
@@ -1,0 +1,34 @@
+from ocp_resources.namespace import Namespace
+
+from trustyai_tests.tests.minio import MinioService, MinioPod, MinioSecret
+
+
+def deploy_namespace_with_minio(name):
+    namespace = Namespace(name=name, label={"modelmesh-enabled": "true"})
+    namespace.deploy()
+    namespace.wait_for_status(status=Namespace.Status.ACTIVE)
+
+    deploy_minio(namespace=namespace)
+
+    return namespace
+
+
+def deploy_minio(namespace):
+    minio_service = MinioService(name="minio", port=9000, target_port=9000, namespace=namespace.name)
+    minio_pod = MinioPod(
+        name="minio", namespace=namespace.name, image="quay.io/trustyai/modelmesh-minio-examples:gauss"
+    )
+    minio_secret = MinioSecret(
+        name="aws-connection-minio-data-connection",
+        namespace=namespace.name,
+        aws_access_key_id="VEhFQUNDRVNTS0VZ",
+        aws_default_region="dXMtc291dGg=",
+        aws_s3_bucket="bW9kZWxtZXNoLWV4YW1wbGUtbW9kZWxz",
+        aws_s3_endpoint="aHR0cDovL21pbmlvOjkwMDA=",
+        aws_secret_access_key="VEhFU0VDUkVUS0VZ",
+    )
+
+    for resource in [minio_service, minio_pod, minio_secret]:
+        resource.deploy()
+
+    return minio_secret

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -169,8 +169,8 @@ def parse_input_data(data_path):
     )
 
 
-def wait_for_model_pods_registered(namespace):
-    """Wait for model pods to be registered by TrustyAIService"""
+def wait_for_modelmesh_pods_registered(namespace):
+    """Wait for modelmesh pods to be registered by TrustyAIService"""
     pods_with_env_var = False
     all_pods_running = False
     timeout = 60 * 10

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -204,12 +204,19 @@ def wait_for_model_pods_registered(namespace):
             sleep(5)
 
 
-def send_data_to_inference_service(namespace, inference_service, data_path, max_retries=5, retry_delay=1):
+def send_data_to_inference_service(
+    namespace, inference_service, data_path, max_retries=5, retry_delay=1, num_batches=None
+):
     inference_route = Route(namespace=namespace.name, name=inference_service.name)
     token = get_ocp_token()
 
+    files_processed = 0
     for root, _, files in os.walk(data_path):
         for file_name in files:
+            if num_batches is not None and files_processed >= num_batches:
+                logger.info(f"Reached the specified number of batches ({num_batches}). Stopping processing.")
+                return
+
             file_path = os.path.join(root, file_name)
             with open(file_path, "r") as file:
                 data = file.read()
@@ -234,6 +241,8 @@ def send_data_to_inference_service(namespace, inference_service, data_path, max_
                 sleep(5)
             else:
                 logger.error(f"Maximum retries reached for file: {file_name}")
+
+            files_processed += 1
 
 
 def upload_data_to_trustyai_service(namespace, data_path):


### PR DESCRIPTION
Add test to ensure that TrustyAI operator can handle multiple namespaces.
The test:
- Deploys 3 namespaces with minio
- Deploys a TrustyAI service for each namespace
- Deploys a ServingRuntime and an InferenceService for each namespace
- For each model, we send training data, apply name mappings, check model metadata
- Schedule a SPD and DIR metric and verify these metrics in Prometheus