### PR TITLE
Change way to get ocp token

### DIFF
--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -3,6 +3,7 @@ import yaml
 from ocp_resources.configmap import ConfigMap
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import get_client
+from ocp_resources.role_binding import RoleBinding
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.trustyai_service import TrustyAIService
 
@@ -27,6 +28,18 @@ def model_namespace(client):
         delete_timeout=600,
     ) as ns:
         ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=120)
+        user_name = "test-user"
+        service_account = ServiceAccount(name=user_name, namespace=ns.name)
+        service_account.deploy()
+        role_binding = RoleBinding(
+            name="test-user-view",
+            namespace=ns.name,
+            subjects_kind="ServiceAccount",
+            subjects_name=user_name,
+            role_ref_kind="ClusterRole",
+            role_ref_name="view",
+        )
+        role_binding.deploy()
         yield ns
 
 

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -46,8 +46,8 @@ class TrustyAIModelMetadata:
         self.num_features = num_features
 
 
-def get_ocp_token():
-    return subprocess.check_output(["oc", "whoami", "-t"]).decode().strip()
+def get_ocp_token(namespace):
+    return subprocess.check_output(["oc", "create", "token", "test-user", "-n", namespace.name]).decode().strip()
 
 
 def get_trustyai_pod(namespace):
@@ -72,7 +72,7 @@ def get_trustyai_model_metadata(namespace):
 
 def send_trustyai_service_request(namespace, endpoint, method, data=None, json=None):
     trustyai_service_route = get_trustyai_service_route(namespace=namespace)
-    token = get_ocp_token()
+    token = get_ocp_token(namespace=namespace)
 
     url = f"https://{trustyai_service_route.host}{endpoint}"
     headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
@@ -208,7 +208,7 @@ def send_data_to_inference_service(
     namespace, inference_service, data_path, max_retries=5, retry_delay=1, num_batches=None
 ):
     inference_route = Route(namespace=namespace.name, name=inference_service.name)
-    token = get_ocp_token()
+    token = get_ocp_token(namespace=namespace)
 
     files_processed = 0
     for root, _, files in os.walk(data_path):


### PR DESCRIPTION
We cannot use `oc whoami -t` in our upstream CI, so we need to deploy a service account and create a token for every namespace that we use in our tests.