### PR TITLE
Add function to check if we have ODH or RHOAI installed

### DIFF
--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -10,8 +10,10 @@ from ocp_resources.trustyai_service import TrustyAIService
 from trustyai_tests.tests.constants import (
     TRUSTYAI_SERVICE,
     MINIO_DATA_CONNECTION_NAME,
+    ODH_OPERATOR,
 )
 from trustyai_tests.tests.minio import MinioSecret, MinioPod, MinioService
+from trustyai_tests.tests.utils import is_odh_or_rhoai
 
 
 @pytest.fixture(scope="session")
@@ -21,10 +23,13 @@ def client():
 
 @pytest.fixture(autouse=True, scope="session")
 def modelmesh_configmap():
-    opendatahub_ns = Namespace(name="opendatahub", ensure_exists=True)
+    operator = is_odh_or_rhoai()
+    namespace = Namespace(
+        name="opendatahub" if operator == ODH_OPERATOR else "redhat-ods-applications", ensure_exists=True
+    )
     with ConfigMap(
         name="model-serving-config",
-        namespace=opendatahub_ns.name,
+        namespace=namespace.name,
         data={"config.yaml": yaml.dump({"podsPerRuntime": 1})},
     ):
         yield

--- a/trustyai_tests/tests/constants.py
+++ b/trustyai_tests/tests/constants.py
@@ -13,3 +13,6 @@ MODEL_DATA_PATH = "./trustyai_tests/model_data"
 MINIO_DATA_CONNECTION_NAME = "aws-connection-minio-data-connection"
 
 KNATIVE_API_GROUP = "serving.knative.dev"
+
+ODH_OPERATOR = "opendatahub-operator"
+RHOAI_OPERATOR = "rhods-operator"


### PR DESCRIPTION
We use this function when creating the modelmesh configmap (in ODH it is created in "opendatahub" namespace, and in RHOAI it is created in the "redhat-ods-applications" namespace)