### PR TITLE
Change modelmesh ConfigMap

### DIFF
--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -34,7 +34,12 @@ def modelmesh_configmap() -> ConfigMap:
     with ConfigMap(
         name="model-serving-config",
         namespace=namespace.name,
-        data={"config.yaml": yaml.dump({"podsPerRuntime": 1})},
+        data={
+            "config.yaml": yaml.dump({
+                "podsPerRuntime": 1,
+                "modelMeshImage": {"name": "quay.io/opendatahub/modelmesh", "tag": "fast"},
+            })
+        },
     ) as cm:
         yield cm
 

--- a/trustyai_tests/tests/drift/conftest.py
+++ b/trustyai_tests/tests/drift/conftest.py
@@ -83,6 +83,6 @@ def gaussian_credit_model(
         annotations={f"{KSERVE_API_GROUP}/deploymentMode": "ModelMesh"},
     ) as inference_service:
         inference_service.wait_for_condition(
-            condition=inference_service.Condition.READY, status=inference_service.Condition.Status.TRUE, timeout=5 * 60
+            condition=inference_service.Condition.READY, status=inference_service.Condition.Status.TRUE, timeout=10 * 60
         )
         yield inference_service

--- a/trustyai_tests/tests/drift/test_drift.py
+++ b/trustyai_tests/tests/drift/test_drift.py
@@ -1,5 +1,4 @@
 import http
-from time import sleep
 
 import pytest
 from ocp_resources.inference_service import InferenceService
@@ -41,21 +40,18 @@ class TestDriftMetrics:
         wait_for_modelmesh_pods_registered(namespace=model_namespace)
 
         path = f"{MODEL_DATA_PATH}/{gaussian_credit_model.name}"
-        sleep(60)
 
         send_data_to_inference_service(
             inference_service=gaussian_credit_model,
             namespace=model_namespace,
             data_path=f"{path}/data_batches",
         )
-        sleep(60)
 
         response = upload_data_to_trustyai_service(
             namespace=model_namespace,
             data_path=f"{path}/training_data.json",
         )
         assert response.status_code == http.HTTPStatus.OK
-        sleep(60)
 
         verify_trustyai_model_metadata(
             namespace=model_namespace,

--- a/trustyai_tests/tests/drift/test_drift.py
+++ b/trustyai_tests/tests/drift/test_drift.py
@@ -1,5 +1,5 @@
 import http
-
+from time import sleep
 
 import pytest
 from ocp_resources.inference_service import InferenceService
@@ -41,18 +41,21 @@ class TestDriftMetrics:
         wait_for_modelmesh_pods_registered(namespace=model_namespace)
 
         path = f"{MODEL_DATA_PATH}/{gaussian_credit_model.name}"
+        sleep(60)
 
         send_data_to_inference_service(
             inference_service=gaussian_credit_model,
             namespace=model_namespace,
             data_path=f"{path}/data_batches",
         )
+        sleep(60)
 
         response = upload_data_to_trustyai_service(
             namespace=model_namespace,
             data_path=f"{path}/training_data.json",
         )
         assert response.status_code == http.HTTPStatus.OK
+        sleep(60)
 
         verify_trustyai_model_metadata(
             namespace=model_namespace,

--- a/trustyai_tests/tests/fairness/conftest.py
+++ b/trustyai_tests/tests/fairness/conftest.py
@@ -95,7 +95,7 @@ def onnx_loan_model_alpha(
         annotations={f"{KSERVE_API_GROUP}/deploymentMode": "ModelMesh"},
     ) as inference_service:
         inference_service.wait_for_condition(
-            condition=inference_service.Condition.READY, status=inference_service.Condition.Status.TRUE, timeout=5 * 60
+            condition=inference_service.Condition.READY, status=inference_service.Condition.Status.TRUE, timeout=10 * 60
         )
         yield inference_service
 
@@ -118,7 +118,7 @@ def onnx_loan_model_beta(
         annotations={f"{KSERVE_API_GROUP}/deploymentMode": "ModelMesh"},
     ) as inference_service:
         inference_service.wait_for_condition(
-            condition=inference_service.Condition.READY, status=inference_service.Condition.Status.TRUE, timeout=5 * 60
+            condition=inference_service.Condition.READY, status=inference_service.Condition.Status.TRUE, timeout=10 * 60
         )
         yield inference_service
 

--- a/trustyai_tests/tests/fairness/test_fairness.py
+++ b/trustyai_tests/tests/fairness/test_fairness.py
@@ -1,4 +1,3 @@
-from time import sleep
 from typing import Any
 
 import pytest
@@ -73,7 +72,6 @@ class TestFairnessMetrics:
         onnx_loan_model_beta: InferenceService,
     ) -> None:
         wait_for_modelmesh_pods_registered(namespace=model_namespace)
-        sleep(60)
 
         for model in [onnx_loan_model_alpha, onnx_loan_model_beta]:
             send_data_to_inference_service(
@@ -81,7 +79,6 @@ class TestFairnessMetrics:
                 namespace=model_namespace,
                 data_path=INPUT_DATA_PATH,
             )
-            sleep(60)
 
             apply_trustyai_name_mappings(
                 namespace=model_namespace,
@@ -89,7 +86,6 @@ class TestFairnessMetrics:
                 input_mappings=INPUT_MAPPINGS,
                 output_mappings=OUTPUT_MAPPINGS,
             )
-            sleep(60)
 
             verify_trustyai_model_metadata(
                 namespace=model_namespace,

--- a/trustyai_tests/tests/fairness/test_fairness.py
+++ b/trustyai_tests/tests/fairness/test_fairness.py
@@ -1,3 +1,4 @@
+from time import sleep
 from typing import Any
 
 import pytest
@@ -72,6 +73,7 @@ class TestFairnessMetrics:
         onnx_loan_model_beta: InferenceService,
     ) -> None:
         wait_for_modelmesh_pods_registered(namespace=model_namespace)
+        sleep(60)
 
         for model in [onnx_loan_model_alpha, onnx_loan_model_beta]:
             send_data_to_inference_service(
@@ -79,6 +81,7 @@ class TestFairnessMetrics:
                 namespace=model_namespace,
                 data_path=INPUT_DATA_PATH,
             )
+            sleep(60)
 
             apply_trustyai_name_mappings(
                 namespace=model_namespace,
@@ -86,6 +89,7 @@ class TestFairnessMetrics:
                 input_mappings=INPUT_MAPPINGS,
                 output_mappings=OUTPUT_MAPPINGS,
             )
+            sleep(60)
 
             verify_trustyai_model_metadata(
                 namespace=model_namespace,

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -107,6 +107,9 @@ def verify_trustyai_model_metadata(
     namespace: Namespace, model: InferenceService, data_path: str, num_batches: int = None
 ):
     response = get_trustyai_model_metadata(namespace=namespace)
+    logger.info(msg=response.text)
+    logger.info(msg=response.content)
+    logger.info(msg=response.json)
     assert (
         response.status_code == http.HTTPStatus.OK
     ), f"Expected status code {http.HTTPStatus.OK}, but got {response.status_code}"
@@ -307,7 +310,7 @@ def send_data_to_inference_service(
                 logger.error(f"Maximum retries reached for file: {file_name}")
 
             files_processed += 1
-            sleep(10)
+            sleep(30)
 
 
 def upload_data_to_trustyai_service(namespace: Namespace, data_path: str) -> Any:
@@ -475,6 +478,9 @@ def apply_trustyai_name_mappings(
     data = {"modelId": inference_service.name, "inputMapping": input_mappings, "outputMapping": output_mappings}
 
     response = send_trustyai_service_request(namespace=namespace, endpoint="/info/names", method="POST", json=data)
+    logger.info(msg=response.text)
+    logger.info(msg=response.content)
+    logger.info(msg=response.json)
     assert response.status_code == http.HTTPStatus.OK, f"Wrong status code: {response.status_code}"
 
 

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -107,9 +107,7 @@ def verify_trustyai_model_metadata(
     namespace: Namespace, model: InferenceService, data_path: str, num_batches: int = None
 ):
     response = get_trustyai_model_metadata(namespace=namespace)
-    logger.info(msg=response.text)
-    logger.info(msg=response.content)
-    logger.info(msg=response.json)
+
     assert (
         response.status_code == http.HTTPStatus.OK
     ), f"Expected status code {http.HTTPStatus.OK}, but got {response.status_code}"
@@ -264,7 +262,7 @@ def wait_for_modelmesh_pods_registered(namespace: Namespace) -> None:
         if not pods_with_env_var or not all_pods_running:
             sleep(5)
 
-    sleep(120)
+    sleep(30)
 
 
 def send_data_to_inference_service(
@@ -297,9 +295,6 @@ def send_data_to_inference_service(
             while retry_count < max_retries:
                 try:
                     response = requests.post(url=url, headers=headers, data=data, verify=False)
-                    logger.info(msg=response.text)
-                    logger.info(msg=response.content)
-                    logger.info(msg=response.json)
 
                     response.raise_for_status()
                     if response.status_code == 200:
@@ -314,7 +309,7 @@ def send_data_to_inference_service(
                 logger.error(f"Maximum retries reached for file: {file_name}")
 
             files_processed += 1
-            sleep(30)
+            sleep(10)
 
 
 def upload_data_to_trustyai_service(namespace: Namespace, data_path: str) -> Any:
@@ -323,9 +318,7 @@ def upload_data_to_trustyai_service(namespace: Namespace, data_path: str) -> Any
 
     logger.info(msg="Uploading data to TrustyAI Service.")
     response = send_trustyai_service_request(namespace=namespace, endpoint="/data/upload", method="POST", data=data)
-    logger.info(msg=response.text)
-    logger.info(msg=response.content)
-    logger.info(msg=response.json)
+
     return response
 
 
@@ -486,9 +479,7 @@ def apply_trustyai_name_mappings(
     data = {"modelId": inference_service.name, "inputMapping": input_mappings, "outputMapping": output_mappings}
 
     response = send_trustyai_service_request(namespace=namespace, endpoint="/info/names", method="POST", json=data)
-    logger.info(msg=response.text)
-    logger.info(msg=response.content)
-    logger.info(msg=response.json)
+
     assert response.status_code == http.HTTPStatus.OK, f"Wrong status code: {response.status_code}"
 
 

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -264,7 +264,7 @@ def wait_for_modelmesh_pods_registered(namespace: Namespace) -> None:
         if not pods_with_env_var or not all_pods_running:
             sleep(5)
 
-    sleep(60)
+    sleep(120)
 
 
 def send_data_to_inference_service(
@@ -297,6 +297,10 @@ def send_data_to_inference_service(
             while retry_count < max_retries:
                 try:
                     response = requests.post(url=url, headers=headers, data=data, verify=False)
+                    logger.info(msg=response.text)
+                    logger.info(msg=response.content)
+                    logger.info(msg=response.json)
+
                     response.raise_for_status()
                     if response.status_code == 200:
                         logger.info(f"Successfully sent data for file: {file_name}")
@@ -318,7 +322,11 @@ def upload_data_to_trustyai_service(namespace: Namespace, data_path: str) -> Any
         data = file.read()
 
     logger.info(msg="Uploading data to TrustyAI Service.")
-    return send_trustyai_service_request(namespace=namespace, endpoint="/data/upload", method="POST", data=data)
+    response = send_trustyai_service_request(namespace=namespace, endpoint="/data/upload", method="POST", data=data)
+    logger.info(msg=response.text)
+    logger.info(msg=response.content)
+    logger.info(msg=response.json)
+    return response
 
 
 def verify_metric_request(namespace: Namespace, endpoint: str, expected_metric_name: str, json_data: Any) -> None:

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -261,7 +261,7 @@ def wait_for_modelmesh_pods_registered(namespace: Namespace) -> None:
         if not pods_with_env_var or not all_pods_running:
             sleep(5)
 
-    sleep(30)
+    sleep(60)
 
 
 def send_data_to_inference_service(


### PR DESCRIPTION
We need to use the `fast` for modelmesh image in its ConfigMap in order to run the tests in OpenShift CI.