### PR TITLE
Change modelmesh configmap fixture

### DIFF
--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -22,13 +22,13 @@ from trustyai_tests.tests.utils import is_odh_or_rhoai
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--modelmesh-configmap", action="store_true", default=False, help="Run tests with modelmesh configmap"
+        "--use-modelmesh-image", action="store_true", default=False, help="Include modelMeshImage in the ConfigMap"
     )
 
 
 @pytest.fixture(scope="session")
-def use_modelmesh_configmap(request):
-    return request.config.getoption("--modelmesh-configmap")
+def use_modelmesh_image(request):
+    return request.config.getoption("--use-modelmesh-image")
 
 
 @pytest.fixture(scope="session")
@@ -37,25 +37,25 @@ def client() -> DynamicClient:
 
 
 @pytest.fixture(autouse=True, scope="session")
-def modelmesh_configmap(use_modelmesh_configmap) -> Optional[ConfigMap]:
-    if use_modelmesh_configmap:
-        operator = is_odh_or_rhoai()
-        namespace = Namespace(
-            name="opendatahub" if operator == ODH_OPERATOR else "redhat-ods-applications", ensure_exists=True
-        )
-        with ConfigMap(
-            name="model-serving-config",
-            namespace=namespace.name,
-            data={
-                "config.yaml": yaml.dump({
-                    "podsPerRuntime": 1,
-                    "modelMeshImage": {"name": "quay.io/opendatahub/modelmesh", "tag": "fast"},
-                })
-            },
-        ) as cm:
-            yield cm
-    else:
-        yield None
+def modelmesh_configmap(use_modelmesh_image) -> Optional[ConfigMap]:
+    operator = is_odh_or_rhoai()
+    namespace = Namespace(
+        name="opendatahub" if operator == ODH_OPERATOR else "redhat-ods-applications", ensure_exists=True
+    )
+
+    config_data = {
+        "podsPerRuntime": 1,
+    }
+
+    if use_modelmesh_image:
+        config_data["modelMeshImage"] = {"name": "quay.io/opendatahub/modelmesh", "tag": "fast"}
+
+    with ConfigMap(
+        name="model-serving-config",
+        namespace=namespace.name,
+        data={"config.yaml": yaml.dump(config_data)},
+    ) as cm:
+        yield cm
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
Changes the mm configmap fixture to always create 1 pod per runtime, but only sets the image to fast if we pass the --use-modelmesh-image argument.