### PR TITLE
Parameterize trustyai_service fixture to run in PVC or DB mode

### DIFF
--- a/trustyai_tests/tests/drift/test_drift.py
+++ b/trustyai_tests/tests/drift/test_drift.py
@@ -20,6 +20,11 @@ from trustyai_tests.tests.constants import (
 )
 
 
+@pytest.mark.parametrize(
+    "trustyai_service",
+    [pytest.param({"storage_type": "pvc"}, id="pvc"), pytest.param({"storage_type": "db"}, id="db")],
+    indirect=True,
+)
 @pytest.mark.openshift
 class TestDriftMetrics:
     """
@@ -35,7 +40,7 @@ class TestDriftMetrics:
     """
 
     def test_gaussian_credit_model_metadata(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         wait_for_modelmesh_pods_registered(namespace=model_namespace)
 
@@ -60,7 +65,7 @@ class TestDriftMetrics:
         )
 
     def test_request_meanshift(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_request(
             namespace=model_namespace,
@@ -70,7 +75,7 @@ class TestDriftMetrics:
         )
 
     def test_schedule_meanshift(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_scheduling(
             namespace=model_namespace,
@@ -79,7 +84,7 @@ class TestDriftMetrics:
         )
 
     def test_meanshift_prometheus_query(
-        self, model_namespace: Namespace, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_trustyai_metric_prometheus(
             namespace=model_namespace,
@@ -89,7 +94,7 @@ class TestDriftMetrics:
         )
 
     def test_request_fouriermmd(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_request(
             namespace=model_namespace,
@@ -99,7 +104,7 @@ class TestDriftMetrics:
         )
 
     def test_schedule_fouriermmd(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_scheduling(
             namespace=model_namespace,
@@ -108,7 +113,7 @@ class TestDriftMetrics:
         )
 
     def test_fouriermmd_prometheus_query(
-        self, model_namespace: Namespace, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_trustyai_metric_prometheus(
             namespace=model_namespace,
@@ -118,7 +123,7 @@ class TestDriftMetrics:
         )
 
     def test_request_kstest(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_request(
             namespace=model_namespace,
@@ -128,7 +133,7 @@ class TestDriftMetrics:
         )
 
     def test_schedule_kstest_scheduling_request(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_scheduling(
             namespace=model_namespace,
@@ -136,7 +141,9 @@ class TestDriftMetrics:
             json_data={"modelId": gaussian_credit_model.name, "referenceTag": "TRAINING"},
         )
 
-    def test_kstest_prometheus_query(self, model_namespace: Namespace, gaussian_credit_model: InferenceService) -> None:
+    def test_kstest_prometheus_query(
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
+    ) -> None:
         verify_trustyai_metric_prometheus(
             namespace=model_namespace,
             model=gaussian_credit_model,
@@ -145,7 +152,7 @@ class TestDriftMetrics:
         )
 
     def test_request_approxkstest(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_request(
             namespace=model_namespace,
@@ -155,7 +162,7 @@ class TestDriftMetrics:
         )
 
     def test_schedule_approxkstest(
-        self, model_namespace: Namespace, trustyai_service_db: TrustyAIService, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_metric_scheduling(
             namespace=model_namespace,
@@ -164,7 +171,7 @@ class TestDriftMetrics:
         )
 
     def test_approxkstest_prometheus_query(
-        self, model_namespace: Namespace, gaussian_credit_model: InferenceService
+        self, model_namespace: Namespace, trustyai_service: TrustyAIService, gaussian_credit_model: InferenceService
     ) -> None:
         verify_trustyai_metric_prometheus(
             namespace=model_namespace,

--- a/trustyai_tests/tests/fairness/test_fairness.py
+++ b/trustyai_tests/tests/fairness/test_fairness.py
@@ -49,6 +49,11 @@ def get_json_data(inference_service: InferenceService) -> dict[str, Any]:
     }
 
 
+@pytest.mark.parametrize(
+    "trustyai_service",
+    [pytest.param({"storage_type": "pvc"}, id="pvc"), pytest.param({"storage_type": "db"}, id="db")],
+    indirect=True,
+)
 @pytest.mark.openshift
 class TestFairnessMetrics:
     """
@@ -67,7 +72,7 @@ class TestFairnessMetrics:
     def test_loan_model_metadata(
         self,
         model_namespace: Namespace,
-        trustyai_service_db: TrustyAIService,
+        trustyai_service: TrustyAIService,
         onnx_loan_model_alpha: InferenceService,
         onnx_loan_model_beta: InferenceService,
     ) -> None:
@@ -96,7 +101,7 @@ class TestFairnessMetrics:
     def test_request_spd(
         self,
         model_namespace: Namespace,
-        trustyai_service_db: TrustyAIService,
+        trustyai_service: TrustyAIService,
         onnx_loan_model_alpha: InferenceService,
         onnx_loan_model_beta: InferenceService,
     ) -> None:
@@ -111,7 +116,7 @@ class TestFairnessMetrics:
     def test_schedule_spd(
         self,
         model_namespace: Namespace,
-        trustyai_service_db: TrustyAIService,
+        trustyai_service: TrustyAIService,
         onnx_loan_model_alpha: InferenceService,
         onnx_loan_model_beta: InferenceService,
     ) -> None:
@@ -125,6 +130,7 @@ class TestFairnessMetrics:
     def test_spd_prometheus_query(
         self,
         model_namespace: Namespace,
+        trustyai_service: TrustyAIService,
         onnx_loan_model_alpha: InferenceService,
         onnx_loan_model_beta: InferenceService,
     ) -> None:
@@ -139,7 +145,7 @@ class TestFairnessMetrics:
     def test_request_dir(
         self,
         model_namespace: Namespace,
-        trustyai_service_db: TrustyAIService,
+        trustyai_service: TrustyAIService,
         onnx_loan_model_alpha: InferenceService,
         onnx_loan_model_beta: InferenceService,
     ) -> None:
@@ -154,7 +160,7 @@ class TestFairnessMetrics:
     def test_schedule_dir(
         self,
         model_namespace: Namespace,
-        trustyai_service_db: TrustyAIService,
+        trustyai_service: TrustyAIService,
         onnx_loan_model_alpha: InferenceService,
         onnx_loan_model_beta: InferenceService,
     ) -> None:
@@ -168,6 +174,7 @@ class TestFairnessMetrics:
     def test_dir_prometheus_query(
         self,
         model_namespace: Namespace,
+        trustyai_service: TrustyAIService,
         onnx_loan_model_alpha: InferenceService,
         onnx_loan_model_beta: InferenceService,
     ) -> None:

--- a/trustyai_tests/tests/multiple_namespaces/test_multiple_namespaces.py
+++ b/trustyai_tests/tests/multiple_namespaces/test_multiple_namespaces.py
@@ -13,6 +13,11 @@ from trustyai_tests.tests.utils import (
 )
 
 
+@pytest.mark.parametrize(
+    "trustyai_services_in_namespaces",
+    [pytest.param({"storage_type": "pvc"}, id="pvc"), pytest.param({"storage_type": "db"}, id="db")],
+    indirect=True,
+)
 @pytest.mark.openshift
 @pytest.mark.heavy
 class TestMultipleNamespaces:


### PR DESCRIPTION
Previously we had separate fixtures for PVC or DB mode. Now, we can parameterize the fixture and pass the storage_type argument ("pvc" to run in PVC mode, anything else to run in DB mode)