### PR TITLE
Drastically increase artifact collection from tests into standardized directory structure

### DIFF
--- a/trustyai_tests/setup/setup_cluster.py
+++ b/trustyai_tests/setup/setup_cluster.py
@@ -25,7 +25,12 @@ from ocp_utilities.operators import install_operator
 
 from timeout_sampler import TimeoutSampler, TimeoutExpiredError
 
-from trustyai_tests.tests.utils import log_namespace_events, get_num_running_containers, log_namespace_pods
+from trustyai_tests.tests.utils import (
+    log_namespace_events,
+    get_num_running_containers,
+    log_namespace_pods,
+    log_namespace_logs,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
@@ -225,9 +230,10 @@ def setup_cluster(args):
         install_dsci(client)
         install_datascience_cluster(client, args.trustyai_manifests_url)
 
-    for namespace in ["opendatahub", "openshift-operators"]:
-        log_namespace_pods(args.artifact_dir, namespace)
-        log_namespace_events(args.artifact_dir, namespace, client)
+    for namespace in ["opendatahub"] + list(set(namespaces.values())):
+        log_namespace_pods(args.artifact_dir, namespace=namespace, directory="cluster-setup")
+        log_namespace_events(args.artifact_dir, client=client, namespace=namespace, directory="cluster-setup")
+        log_namespace_logs(args.artifact_dir, namespace=namespace, directory="cluster-setup")
 
 
 if __name__ == "__main__":

--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -26,7 +26,8 @@ from trustyai_tests.tests.utils import (
     wait_for_mariadb_pods,
     log_namespace_pods,
     log_namespace_events,
-    log_namespace_logs, per_test_artifacting_logic,
+    log_namespace_logs,
+    per_test_artifacting_logic,
 )
 from trustyai_tests.tests.utils import logger, is_odh_or_rhoai, wait_for_trustyai_pod_running
 

--- a/trustyai_tests/tests/conftest.py
+++ b/trustyai_tests/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from time import sleep
 from typing import Any, Generator, Optional
 
@@ -23,6 +24,9 @@ from trustyai_tests.tests.constants import (
 from trustyai_tests.tests.minio import create_minio_secret, create_minio_pod, create_minio_service
 from trustyai_tests.tests.utils import (
     wait_for_mariadb_pods,
+    log_namespace_pods,
+    log_namespace_events,
+    log_namespace_logs, per_test_artifacting_logic,
 )
 from trustyai_tests.tests.utils import logger, is_odh_or_rhoai, wait_for_trustyai_pod_running
 
@@ -56,6 +60,13 @@ def use_modelmesh_image(request):
 @pytest.fixture(scope="session")
 def client() -> DynamicClient:
     yield get_client()
+
+
+@pytest.fixture(autouse=True)
+def test_logging(request, client):
+    per_test_artifacting_logic(request, client, ["pre-test"])
+    yield
+    per_test_artifacting_logic(request, client, ["post-test"])
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/trustyai_tests/tests/utils.py
+++ b/trustyai_tests/tests/utils.py
@@ -883,6 +883,7 @@ def log_namespace_logs(artifacts_dir, namespace, directory, subdirectories=None)
     # restore the kubernetes rest client log level
     logger.setLevel(original_level)
 
+
 def per_test_artifacting_logic(request, client, subdirectories):
     test_name = request.node.name
     if os.environ.get("ARTIFACT_DIR"):
@@ -894,4 +895,3 @@ def per_test_artifacting_logic(request, client, subdirectories):
         log_namespace_logs(artifact_dir, namespace="test-namespace", directory=test_name, subdirectories=subdirectories)
     else:
         pass
-


### PR DESCRIPTION
Significantly more test artifacts are gathered and are stored into a standardized directory structure, see below:

![Screenshot 2025-02-13 at 1 18 27 PM](https://github.com/user-attachments/assets/16a7a0f8-3d26-42d4-9d79-7ffdf8d3f864)

We now gather:
1) Every pod yaml
2) Every container log
3) All namespace events

for the `test-namespace` both before and after each test runs. 